### PR TITLE
Enable TLS and Auth support for SMTP server

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -815,6 +815,7 @@ dependencies = [
  "mailin",
  "mailin-embedded",
  "rand",
+ "rcgen",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1086,6 +1087,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1197,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.20",
+ "yasna",
 ]
 
 [[package]]
@@ -1601,6 +1623,22 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tinyvec"
@@ -2142,3 +2180,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "yasna"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
+dependencies = [
+ "time 0.3.20",
+]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ humansize = "2.0"
 mail-parser = "0.8"
 mailin = "0.6"
 mailin-embedded = { version = "0.7", features = ["rtls"] }
+rcgen = "0.10.0"
 rust-embed = "6.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/src/mail_server.rs
+++ b/backend/src/mail_server.rs
@@ -1,6 +1,9 @@
+use mailin::AuthMechanism;
 /// Receives email over SMTP, parses and broadcasts messages over an internal queue
 use mailin_embedded::{Server, SslConfig};
+use rcgen::{Certificate, CertificateParams, DistinguishedName, DnType};
 use std::{
+    fs,
     io::{self},
     net::ToSocketAddrs,
 };
@@ -89,23 +92,60 @@ impl mailin::Handler for MailHandler {
         _authentication_id: &str,
         _password: &str,
     ) -> mailin::Response {
-        mailin::response::INVALID_CREDENTIALS
+        mailin::response::AUTH_OK
     }
 }
 
 pub fn smtp_listen<A: ToSocketAddrs>(
     addr: A,
     tx: Sender<MailMessage>,
+    enable_tls_auth: bool,
 ) -> Result<(), mailin_embedded::err::Error> {
     let handler = MailHandler::create(tx);
     let mut server = Server::new(handler);
 
     let name = env!("CARGO_PKG_NAME");
 
-    server
-        .with_name(name)
-        .with_ssl(SslConfig::None)?
-        .with_addr(addr)?;
+    // Because mailin-embedded AUTH PLAIN only works over TLS,
+    // we need to have a valid SslConfig if auth is enabled.
+    // If auth is enabled but the SMTP server does not offer TLS
+    // it will returns 503 Bad sequence of commands.
+    match enable_tls_auth {
+        true => {
+            // We generate a self-signed cert on startup
+            event!(Level::INFO, "TLS Auth enabled! Generating certificate...");
+
+            let mut cert_params = CertificateParams::default();
+            let mut dis_name = DistinguishedName::new();
+            dis_name.push(DnType::CommonName, "mailcrab smtp server");
+            cert_params.distinguished_name = dis_name;
+
+            let cert =
+                Certificate::from_params(cert_params).expect("Cannot generate certificates!");
+            fs::write(
+                "cert.pem",
+                cert.serialize_pem()
+                    .expect("Cannot serialize certificate to PEM format!"),
+            )
+            .expect("Cannot write out certificate to a file!");
+            fs::write("key.pem", cert.serialize_private_key_pem())
+                .expect("Cannot write out key to a file!");
+
+            let ssl = SslConfig::SelfSigned {
+                cert_path: "cert.pem".to_string(),
+                key_path: "key.pem".to_string(),
+            };
+            server
+                .with_name(name)
+                .with_auth(AuthMechanism::Plain)
+                .with_ssl(ssl)?
+                .with_addr(addr)?;
+        }
+        false => {
+            let ssl = SslConfig::None;
+            server.with_name(name).with_ssl(ssl)?.with_addr(addr)?;
+        }
+    }
 
     server.serve()?;
 


### PR DESCRIPTION
We use `ENABLE_TLS_AUTH` environment variable to control whether to enable TLS + authentication. `ENABLE_TLS_AUTH` should be set to `true` or `false`. By default, it's set to `false`.

The reason why we have to enable both TLS + auth is because [`mailin-embedded` only support authentication over TLS](https://docs.rs/mailin-embedded/latest/mailin_embedded/enum.AuthMechanism.html#variant.Plain). If auth is enabled but TLS isn't, the SMTP server will return `503 Bad sequence of commands`.

The SMTP server will generate a self-signed certificate on startup if `ENABLE_TLS_AUTH` is set to `true`. We're using [`rcgen`](https://crates.io/crates/rcgen) crate for certificates generation.

This should resolve #31 and (hopefully) resolve #19. 