### PR TITLE
Add Envelope From and Recipient metadata

### DIFF
--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -33,23 +33,40 @@ pub struct MailMessageMetadata {
     pub has_html: bool,
     pub has_plain: bool,
     pub attachments: Vec<AttachmentMetadata>,
+    pub envelope_from: String,
+    pub envelope_recipients: Vec<String>,
 }
 
 impl From<MailMessage> for MailMessageMetadata {
     fn from(message: MailMessage) -> Self {
+        let MailMessage {
+            id,
+            from,
+            to,
+            subject,
+            time,
+            date,
+            size,
+            html,
+            text,
+            opened,
+            attachments,
+            envelope_from,
+            envelope_recipients,
+            ..
+        } = message;
         MailMessageMetadata {
-            id: message.id,
-            from: message.from,
-            to: message.to,
-            subject: message.subject,
-            time: message.time,
-            date: message.date,
-            size: message.size,
-            has_html: !message.html.is_empty(),
-            has_plain: !message.text.is_empty(),
-            opened: message.opened,
-            attachments: message
-                .attachments
+            id,
+            from,
+            to,
+            subject,
+            time,
+            date,
+            size,
+            has_html: !html.is_empty(),
+            has_plain: !text.is_empty(),
+            opened,
+            attachments: attachments
                 .into_iter()
                 .map(|a| AttachmentMetadata {
                     filename: a.filename,
@@ -57,6 +74,8 @@ impl From<MailMessage> for MailMessageMetadata {
                     size: a.size,
                 })
                 .collect::<Vec<AttachmentMetadata>>(),
+            envelope_from,
+            envelope_recipients,
         }
     }
 }
@@ -119,6 +138,8 @@ pub struct MailMessage {
     html: String,
     attachments: Vec<Attachment>,
     raw: String,
+    pub envelope_from: String,
+    pub envelope_recipients: Vec<String>,
 }
 
 impl MailMessage {
@@ -205,6 +226,7 @@ impl TryFrom<mail_parser::Message<'_>> for MailMessage {
             attachments,
             raw,
             headers,
+            ..MailMessage::default()
         })
     }
 }

--- a/frontend/src/list.rs
+++ b/frontend/src/list.rs
@@ -1,7 +1,9 @@
 use crate::types::MailMessageMetadata;
 use js_sys::Date;
 use timeago::Formatter;
-use yew::{function_component, html, use_effect, use_state, Callback, Html, Properties};
+use yew::{
+    function_component, html, html_nested, use_effect, use_state, Callback, Html, Properties,
+};
 use yew_hooks::use_interval;
 
 #[derive(Properties, PartialEq)]
@@ -92,6 +94,16 @@ pub fn list(props: &MessageListProps) -> Html {
                     {&message.size}
                   </span>
                 </span>
+                  <span class="recipients">
+                  <span>{"Recipient(s): "} </span>
+                  {
+                      for message.envelope_recipients.clone().into_iter().map(|addr| html_nested! {
+                          <span class="email">
+                              {addr}
+                          </span>
+                      })
+                  }
+                  </span>
               </li>
             }
         })

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -25,6 +25,8 @@ pub struct MailMessageMetadata {
     pub size: String,
     pub opened: bool,
     pub attachments: Vec<AttachmentMetadata>,
+    pub envelope_from: String,
+    pub envelope_recipients: Vec<String>,
 }
 
 #[derive(Clone, PartialEq, Eq, Deserialize)]
@@ -50,6 +52,8 @@ pub struct MailMessage {
     pub attachments: Vec<Attachment>,
     pub raw: String,
     pub headers: HashMap<String, String>,
+    pub envelope_from: String,
+    pub envelope_recipients: Vec<String>,
 }
 
 #[derive(Serialize, Debug)]

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -197,6 +197,25 @@ header {
       }
     }
 
+    .recipients > span.email + span.email:before {
+      content: ", <";
+      display: inline-block;
+    }
+
+    .recipients {
+      .email {
+        color: rgba(black, 0.3);
+
+        &::before {
+          content: '<';
+        }
+
+        &::after {
+          content: '>';
+        }
+      }
+    }
+
     .preview {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
I needed to keep track of SMTP recipients, which is not stored in the actual e-mail headers. This is useful for e.g. newsletters and other mailing lists, which might have a not-personal `To` header set. (Envelope From and Recipients from the SMTP transaction is the actual information, and headers From and To are only for human consumption)

I also added the info on the frontend:

![image](https://user-images.githubusercontent.com/8278356/229194432-6dfb0792-67f8-4cf6-8c24-b3813a996e3d.png)
