### PR TITLE
Webserver only at localhost

### DIFF
--- a/backend/src/web_server.rs
+++ b/backend/src/web_server.rs
@@ -207,7 +207,7 @@ pub async fn http_server(
 
     app = app.layer(Extension(app_state));
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
     if let Err(e) = axum::Server::bind(&addr)
         .serve(app.into_make_service())


### PR DESCRIPTION
To prevent that the web backend gets exposed to the whole world.