### PR TITLE
Configurable HTTP host address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 ARG TARGETARCH
-ENV HOST="0.0.0.0"
+ENV HTTP_HOST="0.0.0.0"
 WORKDIR /app
 COPY --chmod=755 "./bin/$TARGETARCH" /app/mailcrab
 CMD ["/app/mailcrab"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ docker run --rm -p 3000:1080 -p 2525:1025 marlonb/mailcrab:latest
 
 ## Host
 
-You can specify the host address Mailcrab will listen on using the `HOST` environment variable. In the docker image the default
+You can specify the host address Mailcrab will listen on for HTTP request using
+the `HTTP_HOST` environment variable. In the docker image the default
 address is `0.0.0.0`, when running Mailcrab directly using cargo or a binary, the default is `127.0.0.1`.
 
 ### TLS


### PR DESCRIPTION
Before commit 223dc8dd91a5 where both the web server and the mail server listingen on 0.0.0.0. also known as the any address. It did mean that the web server was always exposed to the whole world.

Commit 223dc8dd91a5 made it possible to (optional) configure the bind address, with default to 127.0.0.1.  Both, web and mail, to same value. Resulting in having the web server listening only on localhost, ment also the mail server listening ONLY on 127.0.0.1.

This change binds mail server hardcoded to 0.0.0.0 and web server is configurable with environment variable HTTP_HOST, defaulting to 127.0.0.1