### PR TITLE
Log only what we got

### DIFF
--- a/backend/src/mail_server.rs
+++ b/backend/src/mail_server.rs
@@ -80,7 +80,7 @@ impl mailin::Handler for MailHandler {
     ) -> mailin::Response {
         event!(
             Level::INFO,
-            "New email on {} from {} to {:?}",
+            "Incoming sofar, helo {} from {} to {:?}",
             domain,
             from,
             to


### PR DESCRIPTION
The 'New email on' was too optimistic and unclear. Optimistic because the SMTP DATA hasn't yet be sent and it could be rejected due parse error.
Unclear because the value for 'on' is the HELO hostname.

Sign-off-by: Geert Stappers <stappers@stappers.it>