### PR TITLE
Added samples/multiple_RCPT_TO

### DIFF
--- a/samples/multiple_RCPT_TO
+++ b/samples/multiple_RCPT_TO
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+SVR="${SMTP_SERVER:-127.0.0.1}"
+PRT="${SMTP_PORT:-1025}"
+
+swaks \
+    --helo sample.direct.ry \
+    --from multi_rcpt_to@script \
+    --to many@mailcrab,foo@bar,foo@baz,dupli@ca.te,dupli@ca.te \
+    --server ${SVR}:${PRT} \
+    --data - << HERE
+From: Many RCPT TO<recipient@metadata>
+To: See Envelope <not@these.headers>
+Subject: Multiple RCPT TO in one SMTP session
+Date: %DATE%
+
+Hi,
+
+This message is for checking
+how mailcrab handles multiple RCPT TO in one SMTP session.
+
+Inspirated by
+  git log --patch 0699315cb2509^1..0699315cb2509
+
+Bye
+
+P.S.
+This message proofs
+that mailcrab can handle multiple RCPT TO in one SMTP session.  :-)
+HERE
+
+# l l


### PR DESCRIPTION
That script in action while `mailcrab-backend` was running in the background ( the four lines after 'DATA' ).

$ samples/multiple_RCPT_TO
=== Trying 127.0.0.1:1025...
=== Connected to 127.0.0.1.
<-  220 mailcrab-backend ESMTP
 -> EHLO sample.direct.ry
<-  250-server offers extensions:
<-  250 8BITMIME
 -> MAIL FROM:<multi_rcpt_to@script>
<-  250 OK
 -> RCPT TO:<many@mailcrab>
<-  250 OK
 -> RCPT TO:<foo@bar>
<-  250 OK
 -> RCPT TO:<foo@baz>
<-  250 OK
 -> RCPT TO:<dupli@ca.te>
<-  250 OK
 -> RCPT TO:<dupli@ca.te>
<-  250 OK
 -> DATA
2023-06-01T19:59:24.414575Z  INFO mailcrab_backend::mail_server:
  New email on sample.direct.ry
  from multi_rcpt_to@script
  to ["many@mailcrab", "foo@bar", "foo@baz", "dupli@ca.te", "dupli@ca.te"]
<-  354 Start mail input; end with <CRLF>.<CRLF>
 -> From: Many RCPT TO<recipient@metadata>
 -> To: See Envelope <not@these.headers>
 -> Subject: Multiple RCPT TO in one SMTP session
 -> Date: Thu, 01 Jun 2023 21:59:24 +0200
 ->
 -> Hi,
 ->
 -> This message is for checking
 -> how mailcrab handles multiple RCPT TO in one SMTP session.
 ->
 -> Inspirated by
 ->   git log --patch 0699315cb2509^1..0699315cb2509
 ->
 -> Bye
 ->
 -> P.S.
 -> This message proofs
 -> that mailcrab can handle multiple RCPT TO in one SMTP session.  :-)
 ->
 -> .
<-  250 OK
 -> QUIT
<-  221 Goodbye
=== Connection closed with remote host.
$