### PR TITLE
Revert "Return message id after a message is parsed"

### DIFF
--- a/backend/src/mail_server.rs
+++ b/backend/src/mail_server.rs
@@ -35,7 +35,7 @@ impl MailHandler {
 }
 
 impl MailHandler {
-    fn parse_mail(&mut self) -> Result<MailMessage, &'static str> {
+    fn parse_mail(&mut self) -> Result<(), &'static str> {
         // parse the email and convert it to a internal data structure
         let parsed = mail_parser::Message::parse(&self.buffer)
             .ok_or("Could not parse email using mail_parser")?;
@@ -48,10 +48,10 @@ impl MailHandler {
 
         // send the message to a internal queue
         self.tx
-            .send(message.clone())
+            .send(message)
             .map_err(|_| "Could not send email to own broadcast channel")?;
 
-        Ok(message)
+        Ok(())
     }
 }
 
@@ -80,7 +80,7 @@ impl mailin::Handler for MailHandler {
     ) -> mailin::Response {
         event!(
             Level::INFO,
-            "Incoming message on {} from {} to {:?}",
+            "New email on {} from {} to {:?}",
             domain,
             from,
             to
@@ -94,16 +94,12 @@ impl mailin::Handler for MailHandler {
     }
 
     fn data_end(&mut self) -> mailin::Response {
-        match self.parse_mail() {
-            Err(e) => {
-                event!(Level::WARN, "Error parsing email: {}", e);
+        if let Err(e) = self.parse_mail() {
+            event!(Level::WARN, "Error parsing email: {}", e);
 
-                mailin::response::Response::custom(500, "Error parsing message".to_string())
-            }
-            Ok(message) => mailin::response::Response::custom(
-                250,
-                format!("2.0.0 Ok: queued as {}", message.id),
-            ),
+            mailin::response::Response::custom(500, "Error parsing message".to_string())
+        } else {
+            mailin::response::OK
         }
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -187,7 +187,7 @@ mod test {
     use lettre::address::Envelope;
     use lettre::message::header::ContentType;
     use lettre::message::{Attachment, MultiPart, SinglePart};
-    use lettre::{Address, Message, SmtpTransport, Transport};
+    use lettre::{Message, SmtpTransport, Transport, Address};
     use std::process::{Command, Stdio};
     use tokio::time::{sleep, Duration};
 
@@ -309,21 +309,10 @@ mod test {
 
         while let Some(Ok(entry)) = paths.next() {
             let message = std::fs::read_to_string(entry.path()).unwrap();
-            let mut lines = message.lines();
+            let mut lines= message.lines();
 
-            let sender = lines
-                .next()
-                .unwrap()
-                .trim_start_matches("Sender: ")
-                .parse::<Address>()
-                .unwrap();
-            let recipients = lines
-                .next()
-                .unwrap()
-                .trim_start_matches("Recipients: ")
-                .split(',')
-                .map(|r| r.trim().parse::<Address>().unwrap())
-                .collect::<Vec<Address>>();
+            let sender = lines.next().unwrap().trim_start_matches("Sender: ").parse::<Address>().unwrap();
+            let recipients = lines.next().unwrap().trim_start_matches("Recipients: ").split(',').map(|r| r.trim().parse::<Address>().unwrap()).collect::<Vec<Address>>();
             let envelope = Envelope::new(Some(sender), recipients).unwrap();
 
             let email = lines.collect::<Vec<&str>>().join("\n");

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -180,7 +180,7 @@ impl TryFrom<mail_parser::Message<'_>> for MailMessage {
             _ => {
                 event!(
                     Level::WARN,
-                    "Could not parse 'From' address header, setting placeholder address."
+                    "Could not parse 'From' address header, setting placeholder 'from' address."
                 );
 
                 Address {
@@ -199,7 +199,7 @@ impl TryFrom<mail_parser::Message<'_>> for MailMessage {
             _ => {
                 event!(
                     Level::WARN,
-                    "Could not parse 'To' address header, setting placeholder address."
+                    "Could not parse 'To' address header, setting placeholder 'to' address."
                 );
 
                 vec![Address {


### PR DESCRIPTION
This reverts commit 92b48d019336296a62485a532d62b711f95120b8. because it had too many diffent changes.