### PR TITLE
Have version information available

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Both the backend server and the frontend are written in Rust. The backend receiv
 
 - `/api/messages` return all message metadata
 - `/api/message/[id]` returns a complete message, given its `id`
+- `/api/version` returns version information about the executable
 - `/ws` send email metadata to each connected client when a new email is received
 
 The frontend initially performs a call to `/api/messages` to receive all existing email metadata and then subscribes for new messages using the websocket connection. When opening a message, the `/api/message/[id]` endpoint is used to retrieve the complete message body and raw email.

--- a/backend/src/mail_server.rs
+++ b/backend/src/mail_server.rs
@@ -10,7 +10,7 @@ use std::{
 use tokio::sync::broadcast::Sender;
 use tracing::{event, Level};
 
-use crate::types::MailMessage;
+use crate::{types::MailMessage, VERSION_BE};
 
 #[derive(Clone, Debug)]
 struct MailHandler {
@@ -58,11 +58,19 @@ impl MailHandler {
 impl mailin::Handler for MailHandler {
     fn helo(&mut self, _ip: std::net::IpAddr, _domain: &str) -> mailin::Response {
         mailin::response::OK
+        // NOTE that response is more as just '250 OK'
     }
 
     fn mail(&mut self, _ip: std::net::IpAddr, _domain: &str, from: &str) -> mailin::Response {
         self.envelope_from = from.to_string();
-        mailin::response::OK
+        // Remote end told us about itself, time to tell more about our self.
+        mailin::response::Response::custom(
+            250,
+            format!(
+                "Pleased to meet you!  By the way, this is version {}",
+                VERSION_BE,
+            ),
+        )
     }
 
     fn rcpt(&mut self, to: &str) -> mailin::Response {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -22,6 +22,11 @@ mod mail_server;
 mod types;
 mod web_server;
 
+pub const VERSION_BE: &'static str = env!("CARGO_PKG_VERSION");
+// Please note that above line of code will yield an error
+// if the environment variable isn't defined,
+// for example if you execute rustc directly without cargo.
+
 pub struct AppState {
     rx: Receiver<MailMessage>,
     storage: RwLock<HashMap<MessageId, MailMessage>>,

--- a/backend/src/web_server.rs
+++ b/backend/src/web_server.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::{
     types::{Action, MailMessage, MailMessageMetadata},
-    AppState, Asset,
+    AppState, Asset, VERSION_BE,
 };
 
 /// send mail message metadata to websocket clients when broadcaster by the SMTP server
@@ -158,6 +158,14 @@ async fn message_body_handler(
     }
 }
 
+/// return version
+async fn version_handler() -> Result<Json<String>, StatusCode> {
+    // Ok(Json(format!("{{ "version_be": "{}" }}", VERSION_BE)))
+    // TODO  Returning much better JSON.
+    //       For starters should all the ' from line below become "
+    Ok(Json(format!("{{ 'version_be': '{}' }}", VERSION_BE)))
+}
+
 async fn not_found() -> Response {
     Response::builder()
         .status(StatusCode::NOT_FOUND)
@@ -204,6 +212,7 @@ pub async fn http_server(
         .route("/api/messages", get(messages_handler))
         .route("/api/message/:id", get(message_handler))
         .route("/api/message/:id/body", get(message_body_handler))
+        .route("/api/version", get(version_handler))
         .nest_service("/static", get(static_handler));
 
     if app_state.index.is_some() {


### PR DESCRIPTION
It is considered a good thing knowing to whom are you talking. For making that possible is the HTTP API extended with end point named 'version' and tells SMTP server tells after 'MAIL FROM' which version it is.
Both "servers" get the version information from the Cargo.toml of the backend.
In the source code are now a NOTE for telling that the response to the SMTP HELO is as just returning a '250 further info'. And there is a TODO that documents that the returned JSON is not JSON.