### PR TITLE
Add default helm values for autoscalling

### DIFF
--- a/charts/mailcrab/values.yaml
+++ b/charts/mailcrab/values.yaml
@@ -2,6 +2,25 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Enable autoscaling using HorizontalPodAutoscaler. Note that the replicaCount would be ignored if autoscaling is enabled
+autoscaling:
+  enabled: false
+#  minReplicas: 2
+#  maxReplicas: 5
+#  metrics:
+#    - type: Resource
+#      resource:
+#        name: cpu
+#        target:
+#          type: Utilization
+#          averageUtilization: 60
+#    - type: Resource
+#      resource:
+#        name: memory
+#        target:
+#          type: Utilization
+#          averageUtilization: 60
+
 # -- Configure the number of replicas to run.
 replicaCount: 1
 


### PR DESCRIPTION
A value https://github.com/tweedegolf/mailcrab/blob/b380da4f0a1d3ac3c162db1f64c899837eef60e9/charts/mailcrab/templates/deployment.yaml#L8 is specified but is not in the `values.yaml`. This causes `helm install` to fail. 

 
<img width="1501" alt="Screenshot 2024-05-18 at 08 42 48" src="https://github.com/tweedegolf/mailcrab/assets/18237132/38051792-1711-46a2-8803-99489f2d1000">


This PR adds the value to the `values.yaml` with `enabled: false` by default.