### PR TITLE
Improvements on #139

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,12 +10,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -45,19 +27,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object",
-]
-
-[[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -111,15 +84,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -127,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -139,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64",
@@ -214,10 +187,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bitflags"
-version = "2.11.0"
+name = "bit-vec"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -230,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -248,9 +230,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -284,20 +266,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.5",
- "stacker",
-]
-
-[[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -363,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -437,9 +409,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email-encoding"
@@ -487,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -624,16 +596,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -643,16 +605,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashify"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149e3ea90eb5a26ad354cfe3cb7f7401b9329032d0235f2687d03a35f30e5d4c"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -737,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -751,7 +714,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -759,15 +721,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -823,12 +784,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -836,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -849,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -863,15 +825,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -883,15 +845,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -927,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -937,12 +899,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -952,16 +914,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itoa"
@@ -981,10 +933,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1003,13 +957,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.19"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",
- "chumsky",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -1032,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1044,9 +997,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1059,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1071,9 +1024,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mail-parser"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
+checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
 dependencies = [
  "hashify",
 ]
@@ -1176,9 +1129,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1225,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1245,15 +1198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1317,16 +1261,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1363,16 +1301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
-dependencies = [
- "ar_archive_writer",
- "cc",
 ]
 
 [[package]]
@@ -1459,9 +1387,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1488,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
@@ -1614,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rusticata-macros"
@@ -1629,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1645,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1655,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1694,9 +1622,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1730,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1840,19 +1768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "stacker"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1982,9 +1897,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1999,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2020,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -2061,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2074,7 +1989,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -2085,6 +1999,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2169,9 +2084,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2181,14 +2096,13 @@ dependencies = [
  "rand",
  "sha1",
  "thiserror",
- "utf-8",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -2227,12 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,9 +2148,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2289,11 +2197,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2302,14 +2210,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2320,23 +2228,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2344,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2357,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2400,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2420,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2500,15 +2404,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2670,6 +2565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -2774,18 +2675,19 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2794,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2806,18 +2708,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2826,18 +2728,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2853,9 +2755,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2864,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2875,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -207,3 +207,78 @@ async fn send_sample_messages() {
         mailer.send_raw(&envelope, email.as_bytes()).unwrap();
     }
 }
+
+async fn send_large_file(size_bytes: usize) -> Result<Response, Box<dyn std::error::Error>> {
+    let smtp_port: u16 = parse_env_var("SMTP_PORT", 1025);
+    let mailer = AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("127.0.0.1".to_string())
+        .port(smtp_port)
+        .build();
+
+    // generates pseudo-random bytes without any added dependencies
+    let body: Vec<u8> = (0..size_bytes).map(|i| (i % 251) as u8).collect();
+
+    let email = Message::builder()
+        .from("sender@example.com".parse()?)
+        .to("recipient@example.com".parse()?)
+        .subject(format!("Large attachment test ({size_bytes} bytes)"))
+        .multipart(
+            MultiPart::mixed()
+                .singlepart(SinglePart::plain("See attached.".to_owned()))
+                .singlepart(
+                    Attachment::new("large.bin".to_owned())
+                        .body(body, ContentType::parse("application/octet-stream")?),
+                ),
+        )?;
+
+    Ok(mailer.send(email).await?)
+}
+
+#[tokio::test]
+async fn receive_large_attachment() {
+    const SIZE: usize = 75 * 1024 * 1024; // 75 MiB
+
+    let join = tokio::task::spawn(run());
+
+    for _ in 0..60 {
+        if get_messages_metadata().await.is_ok() { break; }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    send_large_file(SIZE).await.expect("send failed");
+
+    // give storage a moment to process it, magic number
+    sleep(Duration::from_millis(220)).await;
+
+    let messages = get_messages_metadata().await.unwrap();
+    let meta = messages.last().expect("no message received");
+
+    assert_eq!(meta.attachments.len(), 1);
+    assert_eq!(meta.attachments[0].filename, "large.bin");
+
+    // fetch the full message and hit the new attachment URL
+    let http_port: u16 = parse_env_var("HTTP_PORT", 1080);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    let attachment_bytes = client
+        .get(format!(
+            "http://127.0.0.1:{http_port}/api/message/{}/attachment/0",
+            meta.id
+        ))
+        .send()
+        .await
+        .expect("attachment request failed")
+        .bytes()
+        .await
+        .expect("reading body failed");
+
+    assert_eq!(attachment_bytes.len(), SIZE);
+
+    // verify content matches
+    let expected: Vec<u8> = (0..SIZE).map(|i| (i % 251) as u8).collect();
+    assert_eq!(attachment_bytes.as_ref(), expected.as_slice());
+
+    join.abort();
+}

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -113,7 +113,7 @@ async fn test_receive_messages() -> Result<Vec<Response>, Box<dyn std::error::Er
 }
 
 #[tokio::test]
-async fn receive_message() {
+async fn functional() {
     let join = tokio::task::spawn(run());
 
     // wait for mailcrab to startup
@@ -148,12 +148,9 @@ async fn receive_message() {
     let mut sorted_messages = vec![];
     for id in &responses {
         if let Some(message) = messages.iter().find(|m| m.id.to_string() == *id) {
-            sorted_messages.push(message);
+            sorted_messages.push(message.clone());
         }
     }
-
-    // stop the server
-    join.abort();
 
     assert_eq!(sorted_messages.len(), 3);
     assert!(sorted_messages[0].has_html);
@@ -167,6 +164,53 @@ async fn receive_message() {
     assert!(!sorted_messages[2].has_html);
     assert!(sorted_messages[2].has_plain);
     assert_eq!(sorted_messages[2].attachments.len(), 1);
+
+    // send a large attachment and verify it can be downloaded via the URL endpoint
+    const SIZE: usize = 75 * 1024 * 1024; // 75 MiB
+    send_large_file(SIZE).await.expect("send failed");
+
+    let mut large_meta = None;
+    for _ in 0..300 {
+        let messages = get_messages_metadata().await.unwrap();
+        if let Some(m) = messages
+            .into_iter()
+            .find(|m| m.attachments.iter().any(|a| a.filename == "large.bin"))
+        {
+            large_meta = Some(m);
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    let meta = large_meta.expect("large attachment message not received within timeout");
+
+    assert_eq!(meta.attachments.len(), 1);
+    assert_eq!(meta.attachments[0].filename, "large.bin");
+
+    let http_port: u16 = parse_env_var("HTTP_PORT", 1080);
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+        .unwrap();
+
+    let attachment_bytes = client
+        .get(format!(
+            "http://127.0.0.1:{http_port}/api/message/{}/attachment/0",
+            meta.id
+        ))
+        .send()
+        .await
+        .expect("attachment request failed")
+        .bytes()
+        .await
+        .expect("reading body failed");
+
+    assert_eq!(attachment_bytes.len(), SIZE);
+
+    let expected: Vec<u8> = (0..SIZE).map(|i| (i % 251) as u8).collect();
+    assert_eq!(attachment_bytes.as_ref(), expected.as_slice());
+
+    // stop the server
+    join.abort();
 }
 
 #[tokio::test]
@@ -231,66 +275,4 @@ async fn send_large_file(size_bytes: usize) -> Result<Response, Box<dyn std::err
         )?;
 
     Ok(mailer.send(email).await?)
-}
-
-#[tokio::test]
-async fn receive_large_attachment() {
-    const SIZE: usize = 75 * 1024 * 1024; // 75 MiB
-
-    let join = tokio::task::spawn(run());
-
-    for _ in 0..60 {
-        if get_messages_metadata().await.is_ok() {
-            break;
-        }
-        sleep(Duration::from_millis(100)).await;
-    }
-
-    let messages_before = get_messages_metadata().await.unwrap().len();
-
-    send_large_file(SIZE).await.expect("send failed");
-
-    let mut messages = Vec::new();
-    for _ in 0..100 {
-        messages = get_messages_metadata().await.unwrap();
-        if messages.len() > messages_before {
-            break;
-        }
-        sleep(Duration::from_millis(50)).await;
-    }
-    assert!(
-        messages.len() > messages_before,
-        "no message received within timeout"
-    );
-    let meta = messages.last().expect("no message received");
-
-    assert_eq!(meta.attachments.len(), 1);
-    assert_eq!(meta.attachments[0].filename, "large.bin");
-
-    // fetch the full message and hit the new attachment URL
-    let http_port: u16 = parse_env_var("HTTP_PORT", 1080);
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .unwrap();
-
-    let attachment_bytes = client
-        .get(format!(
-            "http://127.0.0.1:{http_port}/api/message/{}/attachment/0",
-            meta.id
-        ))
-        .send()
-        .await
-        .expect("attachment request failed")
-        .bytes()
-        .await
-        .expect("reading body failed");
-
-    assert_eq!(attachment_bytes.len(), SIZE);
-
-    // verify content matches
-    let expected: Vec<u8> = (0..SIZE).map(|i| (i % 251) as u8).collect();
-    assert_eq!(attachment_bytes.as_ref(), expected.as_slice());
-
-    join.abort();
 }

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -240,16 +240,28 @@ async fn receive_large_attachment() {
     let join = tokio::task::spawn(run());
 
     for _ in 0..60 {
-        if get_messages_metadata().await.is_ok() { break; }
+        if get_messages_metadata().await.is_ok() {
+            break;
+        }
         sleep(Duration::from_millis(100)).await;
     }
 
+    let messages_before = get_messages_metadata().await.unwrap().len();
+
     send_large_file(SIZE).await.expect("send failed");
 
-    // give storage a moment to process it, magic number
-    sleep(Duration::from_millis(220)).await;
-
-    let messages = get_messages_metadata().await.unwrap();
+    let mut messages = Vec::new();
+    for _ in 0..100 {
+        messages = get_messages_metadata().await.unwrap();
+        if messages.len() > messages_before {
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        messages.len() > messages_before,
+        "no message received within timeout"
+    );
     let meta = messages.last().expect("no message received");
 
     assert_eq!(meta.attachments.len(), 1);

--- a/backend/src/web_server.rs
+++ b/backend/src/web_server.rs
@@ -199,6 +199,22 @@ async fn version_handler() -> Result<Json<VersionInfo>, StatusCode> {
     Ok(Json(vi))
 }
 
+/// return raw attachment by index
+async fn attachment_handler(
+    Path((id, index)): Path<(Uuid, usize)>,
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Response, StatusCode> {
+    let storage = state.storage.read()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let message = storage.get(&id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let (mime, bytes) = message.attachment_content(index).ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, mime)
+        .body(Body::from(bytes))
+        .unwrap())
+}
+
 async fn not_found() -> Response {
     Response::builder()
         .status(StatusCode::NOT_FOUND)
@@ -248,6 +264,7 @@ pub async fn web_server(
         .route("/api/delete/{id}", post(message_delete_handler))
         .route("/api/delete-all", post(message_delete_all_handler))
         .route("/api/version", get(version_handler))
+        .route("/api/message/{id}/attachment/{index}", get(attachment_handler))
         .nest_service("/static", get(static_handler))
         .layer(
             TraceLayer::new_for_http()

--- a/backend/src/web_server.rs
+++ b/backend/src/web_server.rs
@@ -150,7 +150,7 @@ async fn message_body_handler(
 ) -> Result<Html<String>, StatusCode> {
     if let Ok(storage) = state.storage.read() {
         match storage.get(&id) {
-            Some(message) => Ok(Html(message.render())),
+            Some(message) => Ok(Html(message.render(&state.prefix))),
             _ => Err(StatusCode::NOT_FOUND),
         }
     } else {
@@ -215,6 +215,24 @@ async fn attachment_handler(
         .unwrap())
 }
 
+/// return the raw message (plain/text)
+async fn message_raw_handler(
+    Path(id): Path<Uuid>,
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Response, StatusCode> {
+    let storage = state.storage.read()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let message = storage.get(&id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let bytes = message.raw_bytes()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Body::from(bytes))
+        .unwrap())
+}
+
 async fn not_found() -> Response {
     Response::builder()
         .status(StatusCode::NOT_FOUND)
@@ -265,6 +283,7 @@ pub async fn web_server(
         .route("/api/delete-all", post(message_delete_all_handler))
         .route("/api/version", get(version_handler))
         .route("/api/message/{id}/attachment/{index}", get(attachment_handler))
+        .route("/api/message/{id}/raw", get(message_raw_handler))
         .nest_service("/static", get(static_handler))
         .layer(
             TraceLayer::new_for_http()

--- a/backend/src/web_server.rs
+++ b/backend/src/web_server.rs
@@ -204,13 +204,23 @@ async fn attachment_handler(
     Path((id, index)): Path<(Uuid, usize)>,
     Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Response, StatusCode> {
-    let storage = state.storage.read()
+    let storage = state
+        .storage
+        .read()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let message = storage.get(&id)
+    let message = storage.get(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let (filename, mime, bytes) = message
+        .attachment_content(index)
         .ok_or(StatusCode::NOT_FOUND)?;
-    let (mime, bytes) = message.attachment_content(index).ok_or(StatusCode::NOT_FOUND)?;
+    let disposition = format!(
+        "attachment; filename=\"{}\"",
+        filename.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    let len = bytes.len();
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, mime)
+        .header(header::CONTENT_LENGTH, len)
+        .header(header::CONTENT_DISPOSITION, disposition)
         .body(Body::from(bytes))
         .unwrap())
 }
@@ -220,15 +230,16 @@ async fn message_raw_handler(
     Path(id): Path<Uuid>,
     Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Response, StatusCode> {
-    let storage = state.storage.read()
+    let storage = state
+        .storage
+        .read()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let message = storage.get(&id)
-        .ok_or(StatusCode::NOT_FOUND)?;
-    let bytes = message.raw_bytes()
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-
+    let message = storage.get(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let bytes = message.raw_bytes().unwrap_or_default();
+    let len = bytes.len();
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(header::CONTENT_LENGTH, len)
         .body(Body::from(bytes))
         .unwrap())
 }
@@ -282,7 +293,10 @@ pub async fn web_server(
         .route("/api/delete/{id}", post(message_delete_handler))
         .route("/api/delete-all", post(message_delete_all_handler))
         .route("/api/version", get(version_handler))
-        .route("/api/message/{id}/attachment/{index}", get(attachment_handler))
+        .route(
+            "/api/message/{id}/attachment/{index}",
+            get(attachment_handler),
+        )
         .route("/api/message/{id}/raw", get(message_raw_handler))
         .nest_service("/static", get(static_handler))
         .layer(

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -46,9 +46,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -523,25 +523,27 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "mailcrab-frontend"
@@ -620,18 +622,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -781,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -812,9 +814,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -895,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
  "tokio-macros",
@@ -905,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1016,9 +1018,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1029,23 +1031,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1053,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1066,18 +1064,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -41,3 +41,15 @@ pub async fn fetch_message(id: &str) -> MailMessage {
         .await
         .unwrap()
 }
+
+pub async fn fetch_raw(id: &str) -> String {
+    let url = get_api_path(&format!("message/{}/raw", id));
+
+    Request::get(&url)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap()
+}

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -24,7 +24,7 @@ pub async fn fetch_messages_metadata() -> Vec<MailMessageMetadata> {
         .await
         .unwrap();
 
-    messages.sort_by(|a, b| a.time.cmp(&b.time));
+    messages.sort_by_key(|a| a.time);
 
     messages
 }
@@ -45,11 +45,13 @@ pub async fn fetch_message(id: &str) -> MailMessage {
 pub async fn fetch_raw(id: &str) -> String {
     let url = get_api_path(&format!("message/{}/raw", id));
 
-    Request::get(&url)
-        .send()
-        .await
-        .unwrap()
+    let response = match Request::get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => return format!("Failed to load raw message: {e}"),
+    };
+
+    response
         .text()
         .await
-        .unwrap()
+        .unwrap_or_else(|e| format!("Failed to read raw message: {e}"))
 }

--- a/frontend/src/message_header.rs
+++ b/frontend/src/message_header.rs
@@ -1,4 +1,4 @@
-use crate::{dark_mode::toggle_body_invert, types::MailMessage};
+use crate::{api::get_api_path, dark_mode::toggle_body_invert, types::MailMessage};
 use yew::{Callback, Html, Properties, function_component, html, html_nested};
 
 #[derive(Properties, Eq, PartialEq)]
@@ -51,30 +51,31 @@ pub fn view(props: &MessageHeaderProps) -> Html {
               <td>{&message.subject}</td>
             </tr>
             <tr>
-            <th>
-              if message.envelope_recipients.len() > 1 {
-                {"Recipients: "}
-              } else {
-                {"Recipient: "}
-              }
-            </th>
-            <td>
-              <span class="recipients">
-                {for message.envelope_recipients.clone().into_iter().map(|addr| html_nested! {
-                  <span class="email">{addr}</span>
-                })}
-              </span>
-            </td>
-          </tr>
+              <th>
+                if message.envelope_recipients.len() > 1 {
+                  {"Recipients: "}
+                } else {
+                  {"Recipient: "}
+                }
+              </th>
+              <td>
+                <span class="recipients">
+                  {for message.envelope_recipients.clone().into_iter().map(|addr| html_nested! {
+                    <span class="email">{addr}</span>
+                  })}
+                </span>
+              </td>
+            </tr>
           </tbody>
         </table>
         <div class="actions">
-          {message.attachments.iter().map(|a| {
+          {message.attachments.iter().enumerate().map(|(index, a)| {
+            let url = get_api_path(&format!("message/{}/attachment/{}", message.id, index));
             html! {
               <a
-                href={format!("data:{};base64,{}", &a.mime, &a.content)}
+                href={url}
                 download={a.filename.clone()}
-                class={&a.mime.replace('/', "-")}
+                class={a.mime.replace('/', "-")}
               >
                 {&a.filename}
                 <span class="size">{&a.size}</span>
@@ -84,7 +85,7 @@ pub fn view(props: &MessageHeaderProps) -> Html {
           <button class="invert-body" onclick={Callback::from(|_| {
             toggle_body_invert();
           })}>
-              {"Invert body"}
+            {"Invert body"}
           </button>
         </div>
       </>

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -35,7 +35,7 @@ pub struct Attachment {
     pub content_id: Option<String>,
     pub mime: String,
     pub size: String,
-    pub content: String,
+//  pub content: String,
 }
 
 #[derive(Clone, PartialEq, Eq, Deserialize, Default)]
@@ -51,7 +51,7 @@ pub struct MailMessage {
     pub text: String,
     pub html: String,
     pub attachments: Vec<Attachment>,
-    pub raw: String,
+//  pub raw: String,
     pub headers: HashMap<String, String>,
     pub envelope_from: String,
     pub envelope_recipients: Vec<String>,

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -35,7 +35,6 @@ pub struct Attachment {
     pub content_id: Option<String>,
     pub mime: String,
     pub size: String,
-//  pub content: String,
 }
 
 #[derive(Clone, PartialEq, Eq, Deserialize, Default)]
@@ -51,7 +50,6 @@ pub struct MailMessage {
     pub text: String,
     pub html: String,
     pub attachments: Vec<Attachment>,
-//  pub raw: String,
     pub headers: HashMap<String, String>,
     pub envelope_from: String,
     pub envelope_recipients: Vec<String>,

--- a/frontend/src/view.rs
+++ b/frontend/src/view.rs
@@ -1,12 +1,10 @@
 use crate::{
-    api::fetch_message,
+    api::{fetch_message, fetch_raw},
     formatted::Formatted,
     overview::Tab,
     plaintext::Plaintext,
     types::{MailMessage, MailMessageMetadata},
 };
-use base64::Engine;
-use base64::engine::general_purpose;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::MouseEvent;
 use yew::{
@@ -25,14 +23,18 @@ pub struct ViewMessageProps {
 #[function_component(ViewMessage)]
 pub fn view(props: &ViewMessageProps) -> Html {
     let message: UseStateHandle<MailMessage> = use_state(Default::default);
+    let raw_content: UseStateHandle<Option<String>> = use_state(|| None);
 
     // fetch message details
     let id = props.message.id.clone();
     let set_tab = props.set_tab.clone();
     let inner_message = message.clone();
     let current_tab = props.active_tab.clone();
-    use_effect_with(id, |message_id| {
+    let raw_content_reset = raw_content.clone();
+
+    use_effect_with(id, move |message_id| {
         let message_id = message_id.clone();
+        raw_content_reset.set(None);
         spawn_local(async move {
             let message = fetch_message(&message_id).await;
             if message.html.is_empty() && current_tab == Tab::Formatted {
@@ -46,12 +48,26 @@ pub fn view(props: &ViewMessageProps) -> Html {
         || ()
     });
 
+    {
+        let id = props.message.id.clone();
+        let raw_content = raw_content.clone();
+        let tab = props.active_tab.clone();
+
+        use_effect_with((id, tab), move |(id, tab)| {
+            if *tab == Tab::Raw {
+                let id = id.clone();
+                let raw_content = raw_content.clone();
+                spawn_local(async move {
+                    raw_content.set(Some(fetch_raw(&id).await));
+                });
+            }
+            || ()
+        });
+    }
+
     if message.id.is_empty() {
         return html! {};
     }
-
-    let raw = general_purpose::STANDARD.decode(&message.raw).unwrap();
-    let raw = String::from_utf8_lossy(&raw).into_owned();
 
     let mut tabs = vec![("Raw", Tab::Raw), ("Headers", Tab::Headers)];
 
@@ -121,7 +137,7 @@ pub fn view(props: &ViewMessageProps) -> Html {
               </tbody>
             </table>
           } else if props.active_tab == Tab::Raw {
-            <pre>{raw}</pre>
+            <pre>{(*raw_content).clone().unwrap_or_default()}</pre>
           }
         </div>
       </div>

--- a/frontend/src/view.rs
+++ b/frontend/src/view.rs
@@ -54,7 +54,7 @@ pub fn view(props: &ViewMessageProps) -> Html {
         let tab = props.active_tab.clone();
 
         use_effect_with((id, tab), move |(id, tab)| {
-            if *tab == Tab::Raw {
+            if *tab == Tab::Raw && raw_content.is_none() {
                 let id = id.clone();
                 let raw_content = raw_content.clone();
                 spawn_local(async move {

--- a/mailcrab/src/types.rs
+++ b/mailcrab/src/types.rs
@@ -21,7 +21,7 @@ pub enum Action {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AttachmentMetadata {
-    filename: String,
+    pub filename: String,
     mime: String,
     size: String,
 }
@@ -144,7 +144,7 @@ pub struct MailMessage {
     headers: HashMap<String, String>,
     text: String,
     html: String,
-    attachments: Vec<Attachment>,
+    pub attachments: Vec<Attachment>,
     raw: String,
     pub envelope_from: String,
     pub envelope_recipients: Vec<String>,
@@ -153,6 +153,12 @@ pub struct MailMessage {
 impl MailMessage {
     pub fn open(&mut self) {
         self.opened = true;
+    }
+
+    pub fn attachment_content(&self, index: usize) -> Option<(String, Vec<u8>)> {
+        let a = self.attachments.get(index)?;
+        let bytes = base64ct::Base64::decode_vec(&a.content).ok()?;
+        Some((a.mime.clone(), bytes))
     }
 
     pub fn render(&self) -> String {

--- a/mailcrab/src/types.rs
+++ b/mailcrab/src/types.rs
@@ -92,6 +92,7 @@ pub struct Attachment {
     content_id: Option<String>,
     mime: String,
     size: String,
+    #[serde(skip)]
     content: String,
 }
 
@@ -145,6 +146,7 @@ pub struct MailMessage {
     text: String,
     html: String,
     pub attachments: Vec<Attachment>,
+    #[serde(skip)]
     raw: String,
     pub envelope_from: String,
     pub envelope_recipients: Vec<String>,
@@ -155,34 +157,33 @@ impl MailMessage {
         self.opened = true;
     }
 
+    pub fn raw_bytes(&self) -> Option<Vec<u8>> {
+        base64ct::Base64::decode_vec(&self.raw).ok()
+    }
+
     pub fn attachment_content(&self, index: usize) -> Option<(String, Vec<u8>)> {
         let a = self.attachments.get(index)?;
         let bytes = base64ct::Base64::decode_vec(&a.content).ok()?;
         Some((a.mime.clone(), bytes))
     }
 
-    pub fn render(&self) -> String {
+    pub fn render(&self, prefix: &str) -> String {
         if self.html.is_empty() {
-            self.text.clone()
-        } else {
-            let mut html = self.html.clone();
-
-            for attachement in &self.attachments {
-                if let Some(content_id) = &attachement.content_id {
-                    let from = format!("cid:{}", content_id.trim_start_matches("cid:"));
-                    let encoded: String = attachement
-                        .content
-                        .chars()
-                        .filter(|c| !c.is_whitespace())
-                        .collect();
-                    let to = format!("data:{};base64,{}", attachement.mime, encoded);
-
-                    html = html.replace(&from, &to);
-                }
-            }
-
-            html
+            return self.text.clone();
         }
+
+        let prefix = if prefix == "/" { "" } else { prefix };
+        let mut html = self.html.clone();
+
+        for (index, attachment) in self.attachments.iter().enumerate() {
+            if let Some(content_id) = &attachment.content_id {
+                let cid = format!("cid:{}", content_id.trim_start_matches("cid:"));
+                let url = format!("{}/api/message/{}/attachment/{}", prefix, self.id, index);
+                html = html.replace(&cid, &url);
+            }
+        }
+
+        html
     }
 }
 

--- a/mailcrab/src/types.rs
+++ b/mailcrab/src/types.rs
@@ -161,10 +161,10 @@ impl MailMessage {
         base64ct::Base64::decode_vec(&self.raw).ok()
     }
 
-    pub fn attachment_content(&self, index: usize) -> Option<(String, Vec<u8>)> {
+    pub fn attachment_content(&self, index: usize) -> Option<(String, String, Vec<u8>)> {
         let a = self.attachments.get(index)?;
         let bytes = base64ct::Base64::decode_vec(&a.content).ok()?;
-        Some((a.mime.clone(), bytes))
+        Some((a.filename.clone(), a.mime.clone(), bytes))
     }
 
     pub fn render(&self, prefix: &str) -> String {
@@ -172,7 +172,7 @@ impl MailMessage {
             return self.text.clone();
         }
 
-        let prefix = if prefix == "/" { "" } else { prefix };
+        let prefix = prefix.trim_end_matches('/');
         let mut html = self.html.clone();
 
         for (index, attachment) in self.attachments.iter().enumerate() {


### PR DESCRIPTION
- Added Content-Disposition + Content-Length to attachment endpoint, dropped dead error branch in raw endpoint, fixed prefix slash bug.
- Replaced magic-number sleep with a poll.
- Removed commented-out fields, made fetch_raw error-graceful, cached Raw tab so toggling doesn't re-download.